### PR TITLE
Fix restoring settings

### DIFF
--- a/src/doria.js
+++ b/src/doria.js
@@ -30,15 +30,17 @@ function restoreConfig() {
     config = JSON.parse(config);
     this.isAccepted = config.isAccepted;
     let acceptedCookie = undefined;
-    for (let i = 0 ; i < config.acceptedCookies.length ; i++) {
-        acceptedCookie = config.acceptedCookies[i];
-        if (acceptedCookie in this.cookies) {
-            this.cookies[acceptedCookie].accepted = true;
-            if (this.cookies[acceptedCookie].handler) {
-                this.cookies[acceptedCookie].handler();
-            }
+    for(let prop in this.cookies){
+        if( config.acceptedCookies.includes(prop)){ 
+            this.cookies[prop].accepted = true;
+            if (this.cookies[prop].handler) {
+                this.cookies[prop].handler();
+            } 
         }
-    }
+        else{
+            this.cookies[prop].accepted = false;
+        }
+      }
 }
 
 function hide(elementClass) {

--- a/src/doria.js
+++ b/src/doria.js
@@ -29,7 +29,6 @@ function restoreConfig() {
     }
     config = JSON.parse(config);
     this.isAccepted = config.isAccepted;
-    let acceptedCookie = undefined;
     for(let prop in this.cookies){
         if( config.acceptedCookies.includes(prop)){ 
             this.cookies[prop].accepted = true;


### PR DESCRIPTION
Fix the issue when Doria restores settings from local storage.
When Doria restores set the accepted field to false if the cookie is not present in the acceptedCookies array in the local storage.