### PR TITLE
Add option to define the state of cookie

### DIFF
--- a/src/doria.js
+++ b/src/doria.js
@@ -101,11 +101,11 @@ class CookieBox {
         saveConfig.bind(this)();
     }
 
-    addCookieSettings(key, label, description, cookies, mandatory=false) {
+    addCookieSettings(key, label, description, cookies, mandatory=false, preSelected=true) {
         this.cookies[key] = {
             label, description, cookies, mandatory
         };
-        this.cookies[key].accepted = true;
+        this.cookies[key].accepted = preSelected;
     }
 
     bake() {


### PR DESCRIPTION
preSelected parameters of addCookieSettings method for define the initial state of cookie enable or disable.

preSelected can be omitted, default value is true.
